### PR TITLE
Do not output ref assemblies

### DIFF
--- a/src/libs/H.Generators.Extensions/build/H.Generators.Extensions.props
+++ b/src/libs/H.Generators.Extensions/build/H.Generators.Extensions.props
@@ -86,14 +86,15 @@
 
     <ItemGroup>
       <ResolvedCompileFileDefinitionsWithoutSystem Include="%(ResolvedCompileFileDefinitions.Identity)" Condition="$(_SystemLibsProperty) != '' AND $(_ResolvedCompileFileDefinitions) != '' AND !$(_SystemLibsProperty.Contains(%(ResolvedCompileFileDefinitions.Filename)))" />
+	  <ResolvedCompileFileDefinitionsWithoutSystemNonRef Include="@(ResolvedCompileFileDefinitionsWithoutSystem->Replace('\ref\', '\lib\'))" />
     </ItemGroup>
 
     <ItemGroup>
-      <None Include="@(ResolvedCompileFileDefinitionsWithoutSystem)" Pack="true" PackagePath="analyzers/dotnet/cs" />
-      <TargetPathWithTargetPlatformMoniker Include="@(ResolvedCompileFileDefinitionsWithoutSystem)" IncludeRuntimeDependency="false" />
+      <None Include="@(ResolvedCompileFileDefinitionsWithoutSystemNonRef)" Pack="true" PackagePath="analyzers/dotnet/cs" />
+      <TargetPathWithTargetPlatformMoniker Include="@(ResolvedCompileFileDefinitionsWithoutSystemNonRef)" IncludeRuntimeDependency="false" />
     </ItemGroup>
 
-    <Message Text="Added generation time reference: %(ResolvedCompileFileDefinitionsWithoutSystem.Identity)" Importance="high" Condition="$(_ResolvedCompileFileDefinitions) != ''"/>
+    <Message Text="Added generation time reference: %(ResolvedCompileFileDefinitionsWithoutSystemNonRef.Identity)" Importance="high" Condition="$(_ResolvedCompileFileDefinitions) != ''"/>
   </Target>
 
 </Project>

--- a/src/libs/H.Generators.Extensions/build/H.Generators.Extensions.props
+++ b/src/libs/H.Generators.Extensions/build/H.Generators.Extensions.props
@@ -86,7 +86,7 @@
 
     <ItemGroup>
       <ResolvedCompileFileDefinitionsWithoutSystem Include="%(ResolvedCompileFileDefinitions.Identity)" Condition="$(_SystemLibsProperty) != '' AND $(_ResolvedCompileFileDefinitions) != '' AND !$(_SystemLibsProperty.Contains(%(ResolvedCompileFileDefinitions.Filename)))" />
-	  <ResolvedCompileFileDefinitionsWithoutSystemNonRef Include="@(ResolvedCompileFileDefinitionsWithoutSystem->Replace('\ref\', '\lib\'))" />
+	  <ResolvedCompileFileDefinitionsWithoutSystemNonRef Include="@(ResolvedCompileFileDefinitionsWithoutSystem->Replace('\ref\', '\lib\')->Replace('/ref/', '/lib/'))" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
There is a issue with NuGet packages which contains ref assemblies like `Microsoft.CSharp` and `System.Runtime.Serialization.Primitives`. Ref assemblies are only for compilation, and not for runtime execution.  I've learned a lot about .NET Standard, NuGet and MSBuild during the last hours. :)

`ResolvedCompileFileDefinitions` points to these `ref files`, and my fix is as simple as replacing `\ref\` with `\lib\`. Ref and lib should always come in pair, so it should be an okay solution to the problem.

I do not know if MSBuild ever will produce forward slashes. The code only handles backward slashes.

### Fixes H.NSwag.Generator

I'm using `H.NSwag.Generator` which is a great tool. I can only build using full MSBuild. It fails using `dotnet build` because `Microsoft.CSharp.dll` can't be loaded. I've tested and verified that `H.NSwag.Generator` works using this fix for `dotnet build`.